### PR TITLE
notifyPath now just calls set

### DIFF
--- a/lib/src/polymer_base.dart
+++ b/lib/src/polymer_base.dart
@@ -220,8 +220,11 @@ abstract class PolymerBase implements CustomElementProxyMixin {
 
   /// Returns true if notification actually took place, based on a dirty check
   /// of whether the new value was already known
-  bool notifyPath(String path, value, {fromAbove}) =>
-      jsElement.callMethod('notifyPath', [path, convertToJs(value), fromAbove]);
+  ///
+  /// Today this just delegates to `set`, which is a bit more expensive but
+  /// does the right thing in all cases. We actually need to update values on
+  /// the JS Side of things for many types of objects.
+  void notifyPath(String path, value) => set(path, value);
 
   /// Serializes a property to its associated attribute.
   ///

--- a/lib/src/polymer_base.dart
+++ b/lib/src/polymer_base.dart
@@ -221,9 +221,9 @@ abstract class PolymerBase implements CustomElementProxyMixin {
   /// Returns true if notification actually took place, based on a dirty check
   /// of whether the new value was already known
   ///
-  /// Today this just delegates to `set`, which is a bit more expensive but
-  /// does the right thing in all cases. We actually need to update values on
-  /// the JS Side of things for many types of objects.
+  /// **Dart Note**: Today this just delegates to `set`, which is a bit more
+  /// expensive but does the right thing in all cases. We actually need to
+  /// update values on the JS Side of things anyways for many types of objects.
   void notifyPath(String path, value) => set(path, value);
 
   /// Serializes a property to its associated attribute.

--- a/test/polymer_base_test.html
+++ b/test/polymer_base_test.html
@@ -81,6 +81,9 @@
     <template>
       <div id="myObject">{{myObject.string}}</div>
       <div id="myString">{{myString}}</div>
+      <template is="dom-repeat" items="{{myArray}}">
+        <span class="item">{{item}}</span>
+      </template>
     </template>
   </dom-module>
   <script>
@@ -93,6 +96,10 @@
         },
         myString: {
           type: Object,
+          notify: true
+        },
+        myArray: {
+          type: Array,
           notify: true
         }
       }


### PR DESCRIPTION
A bit controversial, but this does solve the List related issues. The other option would be to remove notifyPath completely, but I think that will cause a lot of confusion. It also allows us to change this back to calling `notifyPath` in the future if we can come up with a better solution.
